### PR TITLE
Fix bug when down mixing multi-channels WAVs to mono

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ vector<double> getAudioDataFromWavFile(const std::string &filePath) {
         for (int i = 0; i < audioFile.frames(); i++) {
             mono[i] = 0;
 
-            for (int j = 1; j < audioFile.channels(); j++) {
+            for (int j = 0; j < audioFile.channels(); j++) {
                 mono[i] += output[i * audioFile.channels() + j];
             }
 


### PR DESCRIPTION
% While looping each channel values, the index was starting at 1, changed to began at 0
